### PR TITLE
Support newest eurec4a-intake catalog

### DIFF
--- a/eurec4a_environment/nomenclature.py
+++ b/eurec4a_environment/nomenclature.py
@@ -11,12 +11,8 @@ import inspect
 import xarray as xr
 
 
-# TODO: update temperature to be called `ta` once JOANNE dataset is released
-# which uses this definition
-TEMPERATURE = "T"
-# TODO: update altitude to be called `alt` once JOANNE dataset is released
-# which uses this definition
-ALTITUDE = "height"
+TEMPERATURE = "ta"
+ALTITUDE = "alt"
 RELATIVE_HUMIDITY = "rh"
 POTENTIAL_TEMPERATURE = "theta"
 PRESSURE = "p"
@@ -50,7 +46,7 @@ CF_STANDARD_NAMES = {
     TEMPERATURE: "air_temperature",
     ALTITUDE: "geopotential_height",
     RELATIVE_HUMIDITY: "relative_humidity",
-    POTENTIAL_TEMPERATURE: "air_potential_temperature",
+    POTENTIAL_TEMPERATURE: "potential_temperature",
     PRESSURE: "air_pressure",
     SPECIFIC_HUMIDITY: "specific_humidity",
     WIND_SPEED: "wind_speed",

--- a/eurec4a_environment/source_data.py
+++ b/eurec4a_environment/source_data.py
@@ -8,6 +8,8 @@ import xarray as xr
 import yaml
 import intake
 
+from . import nomenclature as nom
+
 
 EUREC4A_INTAKE_CATALOG_URL = (
     "https://raw.githubusercontent.com/eurec4a/eurec4a-intake/master/catalog.yml"
@@ -75,7 +77,12 @@ def open_joanne_dataset(level=3):
     if not level == 3:
         raise NotImplementedError(level)
     cat = get_intake_catalog()
-    ds = cat.dropsondes.to_dask()
+    ds = cat.dropsondes.JOANNE.level3.to_dask()
+    if ds.attrs["JOANNE-version"] == "0.7.0+2.g4a878b3.dirty":
+        # this version is missing units and standard name on the vertical
+        # (height) coordinate
+        ds[nom.ALTITUDE].attrs["units"] = "m"
+        ds[nom.ALTITUDE].attrs["standard_name"] = "geopotential_height"
     return ds.sortby("launch_time")
 
 

--- a/eurec4a_environment/variables/calc_density.py
+++ b/eurec4a_environment/variables/calc_density.py
@@ -18,20 +18,16 @@ def calc_density(
 ):
     # equation: rho = P/(Rd * Tv), where Tv = T(1 + mr/eps)/(1+mr)
 
-    pressure = get_field(ds=ds, name=pres, units="Pa")
-    temp_K = get_field(ds=ds, name=temp, units="K")
-    q = get_field(ds=ds, name=specific_humidity, units="g/kg")
+    da_p = get_field(ds=ds, name=pres, units="Pa")
+    da_temp = get_field(ds=ds, name=temp, units="K")
+    da_qv = get_field(ds=ds, name=specific_humidity, units="g/kg")
 
-    mixing_ratio = q / (1 - q)
+    da_rv = da_qv / (1 - da_qv)
 
-    density = (pressure) / (
-        Rd * (temp_K) * (1 + (mixing_ratio / eps)) / (1 + mixing_ratio)
+    da_rho = (da_p) / (
+        Rd * (da_temp) * (1 + (da_rv / eps)) / (1 + da_rv)
     )
-    density = density.transpose(transpose_coords=True)
+    da_rho.attrs["long_name"] = "density of air"
+    da_rho.attrs["units"] = "kg/m3"
 
-    dims = list(ds.dims.keys())
-    da = xr.DataArray(density, dims=dims, coords={d: ds[d] for d in dims})
-    da.attrs["long_name"] = "density of air"
-    da.attrs["units"] = "kg/m3"
-
-    return da
+    return da_rho

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ INSTALL_REQUIRES = [
     "aiohttp",
     "cfunits",
     "intake-xarray @ git+https://github.com/leifdenby/intake-xarray#egg=intake-xarray",
+    "ipfsspec",
 ]
 setup(
     name="eurec4a-environment",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,7 +44,7 @@ def ds_isentropic_test_profiles():
     ds[nom.TEMPERATURE].attrs["long_name"] = "absolute temperature"
     ds[nom.TEMPERATURE].attrs["standard_name"] = nom.CF_STANDARD_NAMES[nom.TEMPERATURE]
 
-    ds[nom.RELATIVE_HUMIDITY] = 0.95 * xr.ones_like(ds.T)
+    ds[nom.RELATIVE_HUMIDITY] = 0.95 * xr.ones_like(ds[nom.TEMPERATURE])
     ds[nom.RELATIVE_HUMIDITY].attrs["units"] = "1"
     ds[nom.RELATIVE_HUMIDITY].attrs["long_name"] = "relative humidity"
     ds[nom.RELATIVE_HUMIDITY].attrs["standard_name"] = nom.CF_STANDARD_NAMES[

--- a/tests/test_source_datasets.py
+++ b/tests/test_source_datasets.py
@@ -1,9 +1,10 @@
 import eurec4a_environment.source_data
+import eurec4a_environment.nomenclature as nom
 
 
 def test_download_joanne_level3():
     ds = eurec4a_environment.source_data.open_joanne_dataset()
-    assert ds.height.count() > 0
+    assert ds[nom.ALTITUDE].count() > 0
     assert ds.sounding.count() > 0
 
 


### PR DESCRIPTION
Variable naming within JOANNE has changed (version in intake catalog is
now `0.7.0+2.g4a878b3.dirty`). JOANNE is now served with `ipfs` so this must be installed.
Also fixes density calculation to only use coordinates of variables used in calculation.